### PR TITLE
Generate -SNAPSHOT dependencies for maven source

### DIFF
--- a/lib/lure/mvn.go
+++ b/lib/lure/mvn.go
@@ -17,14 +17,22 @@ import (
 )
 
 func mvnOutdated(path string) []moduleVersion {
+
+	mvnInitialise(path)
+
 	cmd := exec.Command("mvn", "versions:display-dependency-updates", "-DprocessDependencyManagement=false")
 	var out bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 	cmd.Dir = path
 	err := cmd.Run()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Println("Error running mvn versions:display-dependency-updates")
+		log.Println(out.String())
+		log.Println(stderr.String())
+		log.Panicln(err)
 	}
 
 	reader := bytes.NewReader(out.Bytes())
@@ -49,12 +57,12 @@ func mvnOutdated(path string) []moduleVersion {
 
 			log.Printf(">%q - %q\n", packageName, packageVersion)
 			mv := moduleVersion{
-				Type: "maven",
+				Type:    "maven",
 				Module:  lastPackage[1] + ":" + lastPackage[2],
 				Current: packageVersion[1],
 				Wanted:  packageVersion[2],
 				Latest:  packageVersion[2],
-				Name:    modulePropertyMap[lastPackage[1] + ":" + lastPackage[2]],
+				Name:    modulePropertyMap[lastPackage[1]+":"+lastPackage[2]],
 			}
 			log.Println(mv)
 			version = append(version, mv)
@@ -64,10 +72,29 @@ func mvnOutdated(path string) []moduleVersion {
 	return version
 }
 
+func mvnInitialise(path string) {
+	//This is required to populate the local cache if the mvn files points to -SNAPSHOT versions
+
+	cmd := exec.Command("mvn", "install", "-DskipTests=true")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	cmd.Dir = path
+	err := cmd.Run()
+
+	if err != nil {
+		log.Println("Error running mvn install -DskipTests=true")
+		log.Println(out.String())
+		log.Println(stderr.String())
+	}
+
+}
+
 func getModulePropertyMap(path string) map[string]string {
 	var moduleProperties map[string]string = make(map[string]string)
 
-	cmd := exec.Command("mvn",  "-q", "--also-make", "exec:exec", "-Dexec.executable=pwd")
+	cmd := exec.Command("mvn", "-q", "--also-make", "exec:exec", "-Dexec.executable=pwd")
 	var out bytes.Buffer
 	var stree bytes.Buffer
 	cmd.Stdout = &out
@@ -76,8 +103,12 @@ func getModulePropertyMap(path string) map[string]string {
 	err := cmd.Run()
 
 	if err != nil {
+		log.Println("Error running mvn -q --also-make exec:exec -Dexec.executable=pwd")
 		fmt.Println(err)
+		log.Println(out.String())
+		fmt.Println(stree.String())
 		log.Fatal(err)
+
 	}
 
 	reader := bytes.NewReader(out.Bytes())
@@ -95,7 +126,7 @@ func getModulePropertyMap(path string) map[string]string {
 		xmlFile, err := os.Open(folder + "/pom.xml")
 		if err != nil {
 			fmt.Println("Error opening file:", err)
-			break;
+			break
 		}
 		defer xmlFile.Close()
 
@@ -105,7 +136,7 @@ func getModulePropertyMap(path string) map[string]string {
 		xml.Unmarshal(b, &mvnProject)
 
 		for _, dep := range mvnProject.Dependencies {
-			if isProperty.MatchString(dep.Version)  {
+			if isProperty.MatchString(dep.Version) {
 				moduleProperties[(dep.GroupId + ":" + dep.ArtifactId)] = strings.TrimRight(strings.TrimLeft(dep.Version, "${"), "}")
 			}
 		}
@@ -114,12 +145,12 @@ func getModulePropertyMap(path string) map[string]string {
 }
 
 type project struct {
-	ModelVersion string `xml:"modelVersion"`
-	Properties PropertyArray `xml:"properties"`
+	ModelVersion string        `xml:"modelVersion"`
+	Properties   PropertyArray `xml:"properties"`
 	Dependencies []struct {
 		ArtifactId string `xml:"artifactId"`
-		GroupId string `xml:"groupId"`
-		Version string `xml:"version"`
+		GroupId    string `xml:"groupId"`
+		Version    string `xml:"version"`
 	} `xml:"dependencies>dependency"`
 }
 
@@ -127,13 +158,12 @@ type PropertyArray struct {
 	PropertyList []Property `xml:",any"`
 }
 type Property struct {
-	XMLName	xml.Name	`xml:""`
-	Value	string		`xml:",chardata"`
+	XMLName xml.Name `xml:""`
+	Value   string   `xml:",chardata"`
 }
 
 type property struct {
 }
-
 
 func mvnUpdateDep(path string, moduleVersion moduleVersion) (bool, error) { //dependency string, version string)
 	dependency := moduleVersion.Module
@@ -144,16 +174,16 @@ func mvnUpdateDep(path string, moduleVersion moduleVersion) (bool, error) { //de
 
 	if moduleVersion.Name != "" {
 		//list all folder with pom.xml
-		cmd := exec.Command("mvn",  "-q", "--also-make", "exec:exec", "-Dexec.executable=pwd")
+		cmd := exec.Command("mvn", "-q", "--also-make", "exec:exec", "-Dexec.executable=pwd")
 		var out bytes.Buffer
-		var stree bytes.Buffer
+		var stderr bytes.Buffer
 		cmd.Stdout = &out
-		cmd.Stderr = &stree
+		cmd.Stderr = &stderr
 		cmd.Dir = path
 		err := cmd.Run()
 
 		if err != nil {
-			log.Println(err)
+			log.Println(stderr.String())
 			log.Fatal(err)
 		}
 
@@ -200,14 +230,11 @@ func mvnUpdateDep(path string, moduleVersion moduleVersion) (bool, error) { //de
 						}
 						if _, ok := path.String(root); ok {
 							b, _ := ioutil.ReadFile(folder2 + "/pom.xml")
-							newContent := strings.Replace(string(b), "<" +
-									propertyToReplace+ ">"+ moduleVersion.Current+
-								"</" + propertyToReplace + ">",
-								"<" + propertyToReplace + ">" +
-									version +
-								"</" + propertyToReplace + ">", -1)
+							newContent := strings.Replace(string(b),
+								"<"+propertyToReplace+">"+moduleVersion.Current+"</"+propertyToReplace+">",
+								"<"+propertyToReplace+">"+version+"</"+propertyToReplace+">", -1)
 
-							err = ioutil.WriteFile(folder2 + "/pom.xml", []byte(newContent), 0)
+							err = ioutil.WriteFile(folder2+"/pom.xml", []byte(newContent), 0)
 							if err != nil {
 								panic(err)
 							}
@@ -217,16 +244,16 @@ func mvnUpdateDep(path string, moduleVersion moduleVersion) (bool, error) { //de
 				}
 			}
 		}
-    } else {
-    	var autoUpdateResult string
-        autoUpdateResult, err = Execute(path, "mvn", "org.codehaus.mojo:versions-maven-plugin:2.4:use-dep-version", "-Dincludes="+dependency, "-DdepVersion="+version)
+	} else {
+		var autoUpdateResult string
+		autoUpdateResult, err = Execute(path, "mvn", "org.codehaus.mojo:versions-maven-plugin:2.4:use-dep-version", "-Dincludes="+dependency, "-DdepVersion="+version)
 		if strings.Contains(autoUpdateResult, fmt.Sprintf("Updated %s:jar:%s to version %s", dependency, moduleVersion.Current, version)) == true {
 			hasUpdate = true
 		}
-    }
+	}
 
 	if hasUpdate == true {
-		log.Printf("Updated %s:%s:jar:%s to version %s",  moduleVersion.Module, dependency, moduleVersion.Current, version)
+		log.Printf("Updated %s:%s:jar:%s to version %s", moduleVersion.Module, dependency, moduleVersion.Current, version)
 	}
 
 	return hasUpdate, err


### PR DESCRIPTION
This is required for maven source that are relying on -SNAPSHOT version. When running `versions:display-dependency-updates`, if the plugin cannot resolve the dependencie it fails. If the dependency are -SNAPSHOT version, they normally won't be available on the remote server (they normally are sitting in your local m2 cache). As a solution we will now force the generation of the local -SNAPSHOT dependency version before running the plugin.

This pullrequest also adds some error logging. 