### PR TITLE
Don't include lure itself from github...

### DIFF
--- a/lure.go
+++ b/lure.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/coveo/lure/lib/lure"
+	"./lib/lure"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/bitbucket"
 )


### PR DESCRIPTION
I could be wayyy off but my understanding is that means building go would always at least partly use some remotely published version and not local changes?

At least that's what I experienced locally...