### PR TITLE
Hg - Cleanup branches with no corresponding open PRs

### DIFF
--- a/lib/lure/git.go
+++ b/lib/lure/git.go
@@ -2,6 +2,7 @@ package lure
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -83,4 +84,10 @@ func (gitRepo GitRepo) LogCommitsBetween(baseRev string, secondRev string) ([]st
 
 	lines := strings.Split(out, "\n")
 	return append(lines[:0], lines[:len(lines)-1]...), nil
+}
+
+func (gitRepo GitRepo) CloseBranch(branch string) error {
+	log.Printf("Closing branch %s.", branch)
+	_, err := gitRepo.Cmd("branch", "-d", GitSanitizeBranchName(branch))
+	return err
 }

--- a/lib/lure/pr.go
+++ b/lib/lure/pr.go
@@ -31,6 +31,7 @@ type PullRequest struct {
 	Source            Source `json:"source"`
 	Dest              Dest   `json:"destination"`
 	CloseSourceBranch bool   `json:"close_source_branch"`
+	State             string `json:"state"`
 }
 
 type PullRequestList struct {
@@ -62,10 +63,10 @@ func createApiRequest(auth Authentication, method string, path string, body io.R
 	return request, err
 }
 
-func getPullRequests(auth Authentication, username string, repoSlug string) []PullRequest {
+func getPullRequests(auth Authentication, username string, repoSlug string, ignoreDeclinedPRs bool) []PullRequest {
 
 	acceptedStates := "state=OPEN"
-	if os.Getenv("IGNORE_DECLINED_PR") != "1" {
+	if !ignoreDeclinedPRs {
 		acceptedStates += "&state=DECLINED"
 	}
 
@@ -96,8 +97,6 @@ func getPullRequests(auth Authentication, username string, repoSlug string) []Pu
 	if e != nil {
 		log.Println("error: " + e.Error())
 	}
-
-	list.PullRequest = append(list.PullRequest, tmpList.PullRequest...)
 
 	return list.PullRequest
 }

--- a/lib/lure/project.go
+++ b/lib/lure/project.go
@@ -19,3 +19,14 @@ type Project struct {
 type LureConfig struct {
 	Projects []Project `json:"projects"`
 }
+
+const (
+	defaultBranchPrefix string = "lure-"
+)
+
+// InitProjectDefault initializes project with default values as necessary
+func InitProjectDefaultValues(project *Project) {
+	if project.BranchPrefix == "" {
+		project.BranchPrefix = "lure-"
+	}
+}

--- a/lib/lure/project.go
+++ b/lib/lure/project.go
@@ -11,6 +11,7 @@ type Project struct {
 	Name          string    `json:"name"`
 	DefaultBranch string    `json:"defaultBranch"`
 	BranchPrefix  string    `json:"branchPrefix"`
+	TrashBranch   string    `json:"trashBranch"`
 	BasePath      string    `json:"basePath"`
 	Commands      []Command `json:"commands"`
 }

--- a/lib/lure/vcs.go
+++ b/lib/lure/vcs.go
@@ -20,6 +20,7 @@ type Repo interface {
 	Branch(branchname string) (string, error)
 	Commit(message string) (string, error)
 	Push() (string, error)
+	CloseBranch(branch string) error
 
 	LogCommitsBetween(baseRev string, secondRev string) ([]string, error)
 }

--- a/lure.go
+++ b/lure.go
@@ -71,6 +71,8 @@ func runMain(config *lure.LureConfig, auth lure.Authentication) {
 	for _, project := range config.Projects {
 		log.Println(fmt.Sprintf("Project: %s/%s", project.Owner, project.Name))
 
+		lure.InitProjectDefaultValues(&project)
+
 		for _, command := range project.Commands {
 			log.Println(fmt.Sprintf("\tCommand: %s", command.Name))
 			commandFunc := getCommand(command.Name)


### PR DESCRIPTION
This is a problem that we want to be addressed with Mercurial. I don't know exactly how this translates to git, so I made it Mercurial specific for now.
I find it hard to maintain the Vcs abstraction with such specific cases. This is why I currently kept everything in the repo package. I could probably move some things in hg package (like FakeMerge)

I also added a project property to set the trash branch to merge into