### PR TITLE
Allow skipping mvn or npm package manager updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,24 @@ First create a `lure.config` in the repository you want to keep your dependencie
 
 The file should look like:
 
-```{
-    "projects": [
-        {
+```
+{
+    "projects": [{
             "vcs": "hg",
             "owner": "dreisch",
             "name": "catfeederhg",
             "defaultBranch": "default",
             "branchPrefix": "lure-",
-            "commands": [
-                {
-                    "name": "updateDependencies"
-                    "args": {
-                        "commitMessage": "Update {{.module}} to {{.version}}\nMYJIRA-1234"
-                    }
+            "skipPackageManager": {
+                "mvn": true,
+                "npm": false
+            },
+            "commands": [{
+                "name": "updateDependencies",
+                "args": {
+                    "commitMessage": "Update {{.module}} to {{.version}}\nMYJIRA-1234"
                 }
-            ]
+            }]
         },
         {
             "vcs": "git",
@@ -34,15 +36,13 @@ The file should look like:
             "name": "catfeedergit",
             "defaultBranch": "master",
             "branchPrefix": "lure-",
-            "commands": [
-                {
-                    "name": "synchronizedBranches",
-                    "args": {
-                        "from": "staging",
-                        "to": "develop"
-                    }
+            "commands": [{
+                "name": "synchronizedBranches",
+                "args": {
+                    "from": "staging",
+                    "to": "develop"
                 }
-            ]
+            }]
         }
     ]
 }
@@ -59,7 +59,7 @@ The possible commands are:
 Other:
 - `owner`: https ://bitbucket.org/**owner**/name
 - `name`: https ://bitbucket.org/owner/**name**
-
+- `skipPackageManager` (Optional):  Allows to explicitely skip a package manager update. Allowed keys are: `npm` and `mvn`.
 
 ## Setup your CI
 

--- a/lib/lure/mvn.go
+++ b/lib/lure/mvn.go
@@ -17,6 +17,12 @@ import (
 )
 
 func mvnOutdated(path string) (error, []moduleVersion) {
+	const pomDefaultFileName = "pom.xml"
+	if !fileExists(path + pomDefaultFileName) {
+		log.Println(pomDefaultFileName + " doesn't exist, skipping mvn update")
+		return nil, make([]moduleVersion, 0, 0)
+	}
+
 	var cmd *exec.Cmd
 	if fileExists("Rules.xml") {
 		cmd = exec.Command("mvn", "-B", "versions:display-dependency-updates", "-DprocessDependencyManagement=false", "-Dmaven.version.rules=file:Rules.xml")

--- a/lib/lure/project.go
+++ b/lib/lure/project.go
@@ -6,15 +6,15 @@ type Command struct {
 }
 
 type Project struct {
-	Vcs           string          `json:"vcs"`
-	Owner         string          `json:"owner"`
-	Name          string          `json:"name"`
-	DefaultBranch string          `json:"defaultBranch"`
-	BranchPrefix  string          `json:"branchPrefix"`
-	TrashBranch   string          `json:"trashBranch"`
-	BasePath      string          `json:"basePath"`
-	PackagesTypes map[string]bool `json:"packageTypes"`
-	Commands      []Command       `json:"commands"`
+	Vcs                string          `json:"vcs"`
+	Owner              string          `json:"owner"`
+	Name               string          `json:"name"`
+	DefaultBranch      string          `json:"defaultBranch"`
+	BranchPrefix       string          `json:"branchPrefix"`
+	TrashBranch        string          `json:"trashBranch"`
+	BasePath           string          `json:"basePath"`
+	SkipPackageManager map[string]bool `json:"skipPackageManager"`
+	Commands           []Command       `json:"commands"`
 }
 
 type LureConfig struct {

--- a/lib/lure/project.go
+++ b/lib/lure/project.go
@@ -6,13 +6,14 @@ type Command struct {
 }
 
 type Project struct {
-	Vcs           string    `json:"vcs"`
-	Owner         string    `json:"owner"`
-	Name          string    `json:"name"`
-	DefaultBranch string    `json:"defaultBranch"`
-	BranchPrefix  string    `json:"branchPrefix"`
-	BasePath      string    `json:"basePath"`
-	Commands      []Command `json:"commands"`
+	Vcs           string          `json:"vcs"`
+	Owner         string          `json:"owner"`
+	Name          string          `json:"name"`
+	DefaultBranch string          `json:"defaultBranch"`
+	BranchPrefix  string          `json:"branchPrefix"`
+	BasePath      string          `json:"basePath"`
+	PackagesTypes map[string]bool `json:"packageTypes"`
+	Commands      []Command       `json:"commands"`
 }
 
 type LureConfig struct {

--- a/lib/lure/repo.go
+++ b/lib/lure/repo.go
@@ -81,7 +81,6 @@ func CheckForUpdatesJobCommand(auth Authentication, project Project, args map[st
 }
 
 func checkForUpdatesJob(auth Authentication, project Project, commitMessage string) error {
-
 	repo, err := cloneRepo(auth, project)
 	if err != nil {
 		return err
@@ -94,17 +93,18 @@ func checkForUpdatesJob(auth Authentication, project Project, commitMessage stri
 
 	modulesToUpdate := make([]moduleVersion, 0, 0)
 
-	if project.PackagesTypes == nil || project.PackagesTypes["npm"] == nil || project.PackagesTypes["npm"] == true {
+	if project.SkipPackageManager == nil || project.SkipPackageManager["npm"] != true {
 		modulesToUpdate = appendIfMissing(modulesToUpdate, npmOutdated(repo.LocalPath()+"/"+project.BasePath))
 	}
 
-	if project.PackagesTypes == nil || project.PackagesTypes["mvn"] == nil || project.PackagesTypes["mvn"] == true {
+	if project.SkipPackageManager == nil || project.SkipPackageManager["mvn"] != true {
 		err, modulesToAdd := mvnOutdated(repo.LocalPath() + "/" + project.BasePath)
 		if err != nil {
 			return err
 		}
+		modulesToUpdate = appendIfMissing(modulesToUpdate, modulesToAdd)
 	}
-	modulesToUpdate = appendIfMissing(modulesToUpdate, modulesToAdd)
+
 	log.Printf("Modules to update : %q", modulesToUpdate)
 
 	ignoreDeclinedPRs := os.Getenv("IGNORE_DECLINED_PR") == "1"

--- a/lib/lure/repo.go
+++ b/lib/lure/repo.go
@@ -80,8 +80,13 @@ func checkForUpdatesJob(auth Authentication, project Project) error {
 	}
 
 	modulesToUpdate := make([]moduleVersion, 0, 0)
-	modulesToUpdate = appendIfMissing(modulesToUpdate, npmOutdated(repo.LocalPath() + "/" + project.BasePath))
-	modulesToUpdate = appendIfMissing(modulesToUpdate, mvnOutdated(repo.LocalPath() + "/" + project.BasePath))
+	if project.PackagesTypes != nil && project.PackagesTypes["mvn"] != false {
+		modulesToUpdate = appendIfMissing(modulesToUpdate, npmOutdated(repo.LocalPath()+"/"+project.BasePath))
+	}
+	if project.PackagesTypes != nil && project.PackagesTypes["npm"] != false {
+		modulesToUpdate = appendIfMissing(modulesToUpdate, mvnOutdated(repo.LocalPath()+"/"+project.BasePath))
+	}
+
 	log.Printf("Modules to update : %q", modulesToUpdate)
 	pullRequests := getPullRequests(auth, project.Owner, project.Name)
 
@@ -138,7 +143,7 @@ func updateModule(auth Authentication, moduleToUpdate moduleVersion, project Pro
 		return
 	}
 
-	if _, err := repo.Commit("Update "+dependencyName+" to "+moduleToUpdate.Latest); err != nil {
+	if _, err := repo.Commit("Update " + dependencyName + " to " + moduleToUpdate.Latest); err != nil {
 		log.Printf("Error: \"Could not commit\" %s", err)
 		return
 	}


### PR DESCRIPTION
We wanted to use this tool, but we don't tave any Maven file in our repository. Update dependencies would fail when trying to execute any `mvn` command.

I added a simple property in the configuration file that allows disabling one of the two package managers. It should be backward compatible :)

Let me know if anything can be improved :)

I'll update the doc if this gets approved