### PR TITLE
Fixed handling default values for commitMessage

### DIFF
--- a/lib/lure/project.go
+++ b/lib/lure/project.go
@@ -22,8 +22,9 @@ type LureConfig struct {
 }
 
 const (
-	defaultBranchPrefix string = "lure-"
-	defaultTrashBranch  string = "closed-branch-trash"
+	defaultBranchPrefix  string = "lure-"
+	defaultTrashBranch   string = "closed-branch-trash"
+	defaultCommitMessage string = "Update {{.module}} to {{.version}}"
 )
 
 // InitProjectDefaultValues initializes project with default values as necessary
@@ -34,10 +35,15 @@ func InitProjectDefaultValues(project *Project) {
 	if project.TrashBranch == "" {
 		project.TrashBranch = defaultTrashBranch
 	}
-	for _, cmd := range project.Commands {
+	for i := range project.Commands {
+		cmd := &project.Commands[i]
+
+		if cmd.Args == nil {
+			cmd.Args = map[string]string{}
+		}
 		_, ok := cmd.Args["commitMessage"]
 		if !ok {
-			cmd.Args["commitMessage"] = "Update {{.module}} to {{.version}}"
+			cmd.Args["commitMessage"] = defaultCommitMessage
 		}
 	}
 }


### PR DESCRIPTION
So TIL in go `range` iterator copies values, so iterating over an array of structs gives you copies. I've spent too much time in the JVM I think ^_^