### PR TITLE
retry on HTTP 429

### DIFF
--- a/lib/lure/pr.go
+++ b/lib/lure/pr.go
@@ -203,5 +203,6 @@ func getHTTPClient() *pester.Client {
 	client := pester.New()
 	client.MaxRetries = 5
 	client.Backoff = pester.ExponentialBackoff
+	client.RetryOnHTTP429 = true
 	return client
 }


### PR DESCRIPTION
The pester library we are using to retry queries that fails doesn't retry on 429 by default.
https://coveord.atlassian.net/browse/on-429