### PR TITLE
fix the duplicated pr detection

### DIFF
--- a/lib/lure/command/updateDependencies.go
+++ b/lib/lure/command/updateDependencies.go
@@ -97,8 +97,8 @@ func updateModule(moduleToUpdate versionManager.ModuleVersion, project project.P
 	if branchPrefix == "" {
 		branchPrefix = "lure-"
 	}
-	dependencyBranchPrefix := branchPrefix + dependencyName
-	dependencyBranchVersionPrefix := dependencyBranchPrefix + "-" + moduleToUpdate.Latest
+	dependencyBranchPrefix := sourceControl.SanitizeBranchName(branchPrefix + dependencyName)
+	dependencyBranchVersionPrefix := sourceControl.SanitizeBranchName(dependencyBranchPrefix + "-" + moduleToUpdate.Latest)
 	branchGUID, _ := guid.V4()
 	var branch = sourceControl.SanitizeBranchName(dependencyBranchVersionPrefix + "-" + branchGUID.String())
 


### PR DESCRIPTION
branch comparison was done with unsanitized name. So if an "invalid"
character was in the prefix, it would get "sanitized" when creating the
branch but not when checking for existing branches (which resulted in
duplicated branches and duplicated pull-requests).