### PR TITLE
Only create the branch if the update modified the code

### DIFF
--- a/lib/lure/command/updateDependencies.go
+++ b/lib/lure/command/updateDependencies.go
@@ -134,12 +134,6 @@ func updateModule(moduleToUpdate versionManager.ModuleVersion, project project.P
 		log.Logger.Fatalf("\"Could not switch to branch %s\" %s", project.DefaultBranch, err)
 	}
 
-	log.Logger.Infof("Creating branch %s", branch)
-	if _, err := sourceControl.Branch(branch); err != nil {
-		log.Logger.Errorf("\"Could not create branch\" %s", err)
-		return
-	}
-
 	hasChanges := false
 
 	switch moduleToUpdate.Type {
@@ -151,6 +145,12 @@ func updateModule(moduleToUpdate versionManager.ModuleVersion, project project.P
 
 	if hasChanges == false {
 		log.Logger.Warnf("An update was available for %s but Lure could not update it", moduleToUpdate.Name)
+		return
+	}
+
+	log.Logger.Infof("Creating branch %s", branch)
+	if _, err := sourceControl.Branch(branch); err != nil {
+		log.Logger.Errorf("\"Could not create branch\" %s", err)
 		return
 	}
 


### PR DESCRIPTION
In mercurial, when we create a branch, we commit it. If there are no
changes, it will create multiple empty branches that will then be closed
and cause many annoyances. To avoid this, branches will only be created
once we're sure there are modification to push.