### PR TITLE
Add a softbranch method on vcs

### DIFF
--- a/lib/lure/command/commandinterfaces.go
+++ b/lib/lure/command/commandinterfaces.go
@@ -10,6 +10,7 @@ type sourceControl interface {
 	Update(string) (string, error)
 	CommitsBetween(string, string) ([]string, error)
 	Branch(string) (string, error)
+	SoftBranch(string) (string, error)
 	Push() (string, error)
 	WorkingPath() string
 	ActiveBranches() ([]string, error)

--- a/lib/lure/command/updateDependencies.go
+++ b/lib/lure/command/updateDependencies.go
@@ -149,7 +149,7 @@ func updateModule(moduleToUpdate versionManager.ModuleVersion, project project.P
 	}
 
 	log.Logger.Infof("Creating branch %s", branch)
-	if _, err := sourceControl.Branch(branch); err != nil {
+	if _, err := sourceControl.SoftBranch(branch); err != nil {
 		log.Logger.Errorf("\"Could not create branch\" %s", err)
 		return
 	}

--- a/lib/lure/vcs/git.go
+++ b/lib/lure/vcs/git.go
@@ -75,6 +75,10 @@ func (gitRepo GitRepo) Branch(branchname string) (string, error) {
 	return gitRepo.Cmd("checkout", "-b", gitRepo.SanitizeBranchName(branchname))
 }
 
+func (gitRepo GitRepo) SoftBranch(branchname string) (string, error) {
+	return gitRepo.Branch(branchname)
+}
+
 func (gitRepo GitRepo) Commit(message string) (string, error) {
 	add, err := gitRepo.Cmd("add", "--all")
 	if err != nil {

--- a/lib/lure/vcs/hg.go
+++ b/lib/lure/vcs/hg.go
@@ -92,7 +92,7 @@ func (hgRepo HgRepo) Update(rev string) (string, error) {
 }
 
 func (hgRepo HgRepo) Branch(branchname string) (string, error) {
-	branch, err := hgRepo.Cmd("branch", hgRepo.SanitizeBranchName(branchname))
+	branch, err := hgRepo.SoftBranch(branchname)
 	if err != nil {
 		return "", err
 	}
@@ -103,6 +103,10 @@ func (hgRepo HgRepo) Branch(branchname string) (string, error) {
 	}
 
 	return branch, nil
+}
+
+func (hgRepo HgRepo) SoftBranch(branchname string) (string, error) {
+	return hgRepo.Cmd("branch", hgRepo.SanitizeBranchName(branchname))
 }
 
 func (hgRepo HgRepo) Commit(message string) (string, error) {

--- a/lib/lure/vcs/vcs.go
+++ b/lib/lure/vcs/vcs.go
@@ -47,6 +47,7 @@ type SourceControl interface {
 	Cmd(args ...string) (string, error)
 	Update(rev string) (string, error)
 	Branch(branchname string) (string, error)
+	SoftBranch(branchname string) (string, error)
 	Commit(message string) (string, error)
 	Push() (string, error)
 	ActiveBranches() ([]string, error)


### PR DESCRIPTION
Mercurial wants you to commit a new branch, to avoid commiting a branch
with change then commiting an empty changeset (which will fail) and to
allow people to use git and mercurial independently, a concept of
softbranch was introduced for cases where you only want to create a
branch without commiting the "action" of creating a branch.