### PR TITLE
Adjusted bitbucket PR fetching to prevent declining legit PRs

### DIFF
--- a/lib/lure/repositorymanagementsystem/bitbucket.go
+++ b/lib/lure/repositorymanagementsystem/bitbucket.go
@@ -123,8 +123,16 @@ func (bitbucket BitBucket) GetPullRequests(username string, repoSlug string, ign
 			ID:                bitBucketPr.ID,
 			Title:             bitBucketPr.Title,
 			Description:       bitBucketPr.Description,
-			Source:            &bitBucketPr.Source,
-			Dest:              &bitBucketPr.Dest,
+			Source:            &source{
+				Branch: branch{
+					Name: bitBucketPr.Source.GetName(),
+				},
+			},
+			Dest:              &dest{
+				Branch: branch{
+					Name: bitBucketPr.Dest.GetName(),
+				},
+			},
 			CloseSourceBranch: bitBucketPr.CloseSourceBranch,
 			State:             bitBucketPr.State,
 			Reviewers:         bitBucketPr.Reviewers,


### PR DESCRIPTION
Turns out the problem of having legit PRs declined was due to the fact that the PR listing in the bitbucket implementation was not using pointers properly.

We ended up having all the PRs, but all with the same branch name (the last one encountered) and ours was one fitting a dependency with a declined PR. So it declined everything it encountered.

So the fix is to mimic what has been done elsewhere with a copy instead of giving a pointer

Example of logging I added:
`INFO[0054]/Users/stoussaint/coveo/projects/lure/lib/lure/repositorymanagementsystem/bitbucket.go:138 github.com/coveooss/lure/lib/lure/repositorymanagementsystem.BitBucket.GetPullRequests() %!s(int=7) | Update maven dependency junit.jupiter.version to version 5.5.1 | &{{lure_COM-65-mockito_version-3_0_0-3f0956c1-566e-4cd7-8537-db8c3b05d303}} 
INFO[0054]/Users/stoussaint/coveo/projects/lure/lib/lure/repositorymanagementsystem/bitbucket.go:138 github.com/coveooss/lure/lib/lure/repositorymanagementsystem.BitBucket.GetPullRequests() %!s(int=8) | Update maven dependency mockito.version to version 3.0.0 | &{{lure_COM-65-mockito_version-3_0_0-3f0956c1-566e-4cd7-8537-db8c3b05d303}} `