### PR TITLE
Adding json mapping to PullRequest type

### DIFF
--- a/lib/lure/repositorymanagementsystem/pullRequest.go
+++ b/lib/lure/repositorymanagementsystem/pullRequest.go
@@ -5,12 +5,12 @@ type Branch interface {
 }
 
 type PullRequest struct {
-	ID                int
-	Title             string
-	Description       string
-	Source            Branch
-	Dest              Branch
-	CloseSourceBranch bool
-	State             string
-	Reviewers         []user
+	ID                int    `json:"id"`
+	Title             string `json:"title"`
+	Description       string `json:"description"`
+	Source            Branch `json:"source"`
+	Dest              Branch `json:"dest"`
+	CloseSourceBranch bool   `json:"close_source_branch"`
+	State             string `json:"state"`
+	Reviewers         []user `json:"reviewers"`
 }


### PR DESCRIPTION
Seems there was a missing mapping for the PullRequest type which is used for the BB creation call. 

`{"type": "error", "error": {"fields": {"source": ["This field is required."], "title": ["This field is required."]}, "message": "Bad request"}}time="2020-10-26T04:12:36Z" level=info msg="switching /tmp/f0d8b439-c10e-4d6f-8668-aeab8d41c38c to default branch: master"`

Properties were capitalized (e.g. `Source` instead of `source` within the payload) and thus breaking.

This type is also used by 
- the github class, in the get PRs
- the bitbucket class, in the get PRs

but in both cases, it is used as the return type where all properties are copied from the actual response which used another type. It does not affect those :famouslastwords: