### PR TITLE
Adding support of '/' in branch name in Git

### DIFF
--- a/lib/lure/vcs/git.go
+++ b/lib/lure/vcs/git.go
@@ -36,7 +36,7 @@ func NewGit(auth Authentication, source string, to string, basePath string) (Git
 
 func (gitRepo GitRepo) SanitizeBranchName(branchName string) string {
 	//TODO: https://wincent.com/wiki/Legal_Git_branch_names
-	reg, _ := regexp.Compile("[^a-zA-Z0-9_-]+")
+	reg, _ := regexp.Compile("[^a-zA-Z0-9/_-]+")
 	safe := reg.ReplaceAllString(branchName, "_")
 	return safe
 }


### PR DESCRIPTION
It was supported on Mercurial. I don't see why it could not be supported as well 